### PR TITLE
upper bound for qdiff in the event pass optimum

### DIFF
--- a/R/cellassign.R
+++ b/R/cellassign.R
@@ -108,6 +108,7 @@ cellassign <- function(exprs_obj,
                        dirichlet_concentration = 1e-2,
                        rel_tol_adam = 1e-4,
                        rel_tol_em = 1e-4,
+                       rel_tol_qdiff = 1e-4,
                        max_iter_adam = 1e5,
                        max_iter_em = 20,
                        learning_rate = 0.1,
@@ -201,6 +202,7 @@ cellassign <- function(exprs_obj,
                                 max_iter_em = max_iter_em,
                                 learning_rate = learning_rate,
                                 min_delta = min_delta,
+                                rel_tol_qdiff = rel_tol_qdiff,
                                 dirichlet_concentration = dirichlet_concentration)
 
     return(structure(res, class = "cellassign_fit"))

--- a/R/inference-tensorflow.R
+++ b/R/inference-tensorflow.R
@@ -40,6 +40,7 @@ inference_tensorflow <- function(Y,
                                  learning_rate = 1e-4,
                                  random_seed = NULL,
                                  min_delta = 2,
+                                 rel_tol_qdiff = 1e-4,
                                  dirichlet_concentration = rep(1e-2, C)) {
   tf$reset_default_graph()
 
@@ -186,9 +187,11 @@ inference_tensorflow <- function(Y,
 
       Q_old <- sess$run(Q, feed_dict = gfd)
       Q_diff <- rel_tol_adam + 1
+      Q_diff_min <- Q_diff
+      Q_diff_delta <- -Q_diff
       mi = 0
 
-      while(mi < max_iter_adam && Q_diff > rel_tol_adam) {
+      while(mi < max_iter_adam && Q_diff > rel_tol_adam && Q_diff_delta < rel_tol_qdiff) {
         mi <- mi + 1
 
         sess$run(train, feed_dict = gfd)
@@ -199,6 +202,8 @@ inference_tensorflow <- function(Y,
           }
           Q_new <- sess$run(Q, feed_dict = gfd)
           Q_diff = -(Q_new - Q_old) / abs(Q_old)
+          Q_diff_min <- min(Q_diff_min, Q_diff)
+          Q_diff_delta <- Q_diff - Q_diff_min
           Q_old <- Q_new
         }
       } # End gradient descent
@@ -254,4 +259,3 @@ inference_tensorflow <- function(Y,
   return(rlist)
 
 }
-


### PR DESCRIPTION
I ran into some situations in the pipeline where the set parameters would go past the minimum and start climbing, so this would prevent it from climbing too far.